### PR TITLE
fix: correct channel id from openclaw-weibo to weibo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "./index.ts"
     ],
     "channel": {
-      "id": "openclaw-weibo",
+      "id": "weibo",
       "label": "Weibo",
       "selectionLabel": "Weibo (微博)",
       "docsPath": "/channels/weibo",


### PR DESCRIPTION
openclaw.channel.id in package.json was "openclaw-weibo" while openclaw.plugin.json, index.ts, and src/channel.ts all use "weibo", causing a plugin id validation failure at load time.