### PR TITLE
fix: coerce numeric appId/appSecret to string when reading config

### DIFF
--- a/src/__tests__/accounts.test.ts
+++ b/src/__tests__/accounts.test.ts
@@ -55,6 +55,20 @@ describe("resolveWeiboAccount", () => {
     expect(account.configured).toBe(false);
   });
 
+  it("treats numeric appId from config as string (config set stores numbers)", () => {
+    const cfg = {
+      channels: {
+        weibo: {
+          appId: 123456789 as unknown as string,
+          appSecret: "test-secret",
+        },
+      },
+    } as ClawdbotConfig;
+    const account = resolveWeiboAccount({ cfg, accountId: "default" });
+    expect(account.appId).toBe("123456789");
+    expect(account.configured).toBe(true);
+  });
+
   it("falls back to default endpoints when hot-reload leaves endpoint fields as empty strings", () => {
     const cfg: ClawdbotConfig = {
       channels: {

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -6,6 +6,9 @@ const DEFAULT_WS_ENDPOINT = "ws://open-im.api.weibo.com/ws/stream";
 const DEFAULT_TOKEN_ENDPOINT = "http://open-im.api.weibo.com/open/auth/ws_token";
 
 function readOptionalNonBlankString(value: unknown): string | undefined {
+  if (typeof value === "number" && !Number.isNaN(value)) {
+    return String(value);
+  }
   if (typeof value !== "string") {
     return undefined;
   }


### PR DESCRIPTION
When using `openclaw config set 'channels.weibo.appId' '123456789'`, YAML/JSON may store the value as a number. The previous readOptionalNonBlankString helper returned undefined for non-string values, causing the account to appear as unconfigured.

Fix: coerce finite numbers to strings, matching the existing coercion already present in token.ts (String(appId)).