### PR TITLE
fix: handle missing withReplyDispatcher in weibo channel runtime

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -407,47 +407,67 @@ export async function handleWeiboMessage(params: HandleWeiboMessageParams): Prom
   log(`weibo[${accountId}]: dispatching to agent (session=${route.sessionKey})`);
 
   try {
-    const result = await core.channel.reply.withReplyDispatcher({
+    const onSettled = async () => {
+      streamDebug("dispatcher_settled_before", {
+        currentOutboundMessageId,
+        currentOutboundChunkId,
+        ...outboundStream.snapshot(),
+      });
+      await outboundStream.settle();
+      streamDebug("dispatcher_settled_after", {
+        currentOutboundMessageId,
+        currentOutboundChunkId,
+        ...outboundStream.snapshot(),
+      });
+      currentOutboundMessageId = null;
+      currentOutboundChunkId = 0;
+      markDispatchIdle();
+    };
+
+    const runDispatch = () => core.channel.reply.dispatchReplyFromConfig({
+      ctx: ctxPayload,
+      cfg,
       dispatcher,
-      onSettled: async () => {
-        streamDebug("dispatcher_settled_before", {
-          currentOutboundMessageId,
-          currentOutboundChunkId,
-          ...outboundStream.snapshot(),
-        });
-        await outboundStream.settle();
-        streamDebug("dispatcher_settled_after", {
-          currentOutboundMessageId,
-          currentOutboundChunkId,
-          ...outboundStream.snapshot(),
-        });
-        currentOutboundMessageId = null;
-        currentOutboundChunkId = 0;
-        markDispatchIdle();
-      },
-      run: () => core.channel.reply.dispatchReplyFromConfig({
-        ctx: ctxPayload,
-        cfg,
-        dispatcher,
-        replyOptions: {
-          ...replyOptions,
-          disableBlockStreaming,
-          onPartialReply: async (payload) => {
-            streamDebug("on_partial_reply", {
-              textLen: (payload.text ?? "").length,
-              preview: (payload.text ?? "").slice(0, 80),
-            });
-            await outboundStream.pushPartialSnapshot(payload.text ?? "");
-          },
-          onAssistantMessageStart: () => {
-            streamDebug("on_assistant_message_start");
-          },
-          onReasoningEnd: () => {
-            streamDebug("on_reasoning_end");
-          },
+      replyOptions: {
+        ...replyOptions,
+        disableBlockStreaming,
+        onPartialReply: async (payload) => {
+          streamDebug("on_partial_reply", {
+            textLen: (payload.text ?? "").length,
+            preview: (payload.text ?? "").slice(0, 80),
+          });
+          await outboundStream.pushPartialSnapshot(payload.text ?? "");
         },
-      }),
+        onAssistantMessageStart: () => {
+          streamDebug("on_assistant_message_start");
+        },
+        onReasoningEnd: () => {
+          streamDebug("on_reasoning_end");
+        },
+      },
     });
+
+    const withReplyDispatcher = (core.channel.reply as {
+      withReplyDispatcher?: (params: {
+        dispatcher: unknown;
+        run: () => Promise<{ queuedFinal: boolean; counts: { final: number } }>;
+        onSettled?: () => Promise<void> | void;
+      }) => Promise<{ queuedFinal: boolean; counts: { final: number } }>;
+    }).withReplyDispatcher;
+
+    const result = typeof withReplyDispatcher === "function"
+      ? await withReplyDispatcher({
+        dispatcher,
+        onSettled,
+        run: runDispatch,
+      })
+      : await (async () => {
+        try {
+          return await runDispatch();
+        } finally {
+          await onSettled();
+        }
+      })();
 
     log(`weibo[${accountId}]: dispatch complete (queuedFinal=${result.queuedFinal}, replies=${result.counts.final})`);
   } catch (err) {


### PR DESCRIPTION
### Motivation
- Production observed runtime error `TypeError: core.channel.reply.withReplyDispatcher is not a function` when certain OpenClaw runtimes do not expose that helper. 
- Ensure the Weibo channel remains compatible across runtime versions that provide `dispatchReplyFromConfig` but not `withReplyDispatcher`.

### Description
- Refactored the dispatch flow in `src/bot.ts` to extract an `onSettled` cleanup callback and a `runDispatch` function that calls `core.channel.reply.dispatchReplyFromConfig` with existing reply hooks. 
- Added a runtime compatibility check that uses `core.channel.reply.withReplyDispatcher` when present, and otherwise falls back to invoking `runDispatch` inside a `try/finally` that calls `onSettled` to preserve settle/cleanup behavior. 
- Preserved existing behavior including `outboundStream.settle`, chunk state reset, and `markDispatchIdle` in both code paths.

### Testing
- Ran unit tests with `npm run test:unit` and all tests passed (`Test Files 16 passed, Tests 76 passed`).
- Ran full CI check with `npm run ci:check` (which runs `npx tsc --noEmit && npm run test:unit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9accd85748328a82ac29521fca3bf)